### PR TITLE
feat: implement green brand theme for shadcn components

### DIFF
--- a/client/app/globals.css
+++ b/client/app/globals.css
@@ -49,72 +49,108 @@
 }
 
 :root {
-  --radius: 0.625rem;
-  --background: oklch(1 0 0);
-  --foreground: oklch(0.145 0 0);
-  --card: oklch(1 0 0);
-  --card-foreground: oklch(0.145 0 0);
-  --popover: oklch(1 0 0);
-  --popover-foreground: oklch(0.145 0 0);
-  --primary: oklch(0.205 0 0);
-  --primary-foreground: oklch(0.985 0 0);
-  --secondary: oklch(0.97 0 0);
-  --secondary-foreground: oklch(0.205 0 0);
-  --muted: oklch(0.97 0 0);
-  --muted-foreground: oklch(0.556 0 0);
-  --accent: oklch(0.97 0 0);
-  --accent-foreground: oklch(0.205 0 0);
+  --radius: 0.75rem;
+
+  /* Backgrounds */
+  --background: oklch(0.98 0.002 120); /* Off-white */
+  --foreground: oklch(0.25 0.01 120); /* Dark gray/black */
+
+  /* Cards */
+  --card: oklch(1 0 0); /* Pure white */
+  --card-foreground: oklch(0.25 0.01 120);
+
+  /* Primary - Your main green */
+  --primary: oklch(0.68 0.15 135); /* Mid forest green */
+  --primary-foreground: oklch(1 0 0); /* White text */
+
+  /* Secondary - Light green accent */
+  --secondary: oklch(0.92 0.12 130); /* Light lime green */
+  --secondary-foreground: oklch(0.25 0.01 120);
+
+  /* Muted */
+  --muted: oklch(0.95 0.005 120);
+  --muted-foreground: oklch(0.55 0.015 120);
+
+  /* Accent - Bright green */
+  --accent: oklch(0.95 0.18 130); /* Bright chartreuse */
+  --accent-foreground: oklch(0.25 0.01 120);
+
+  /* Destructive (errors) */
   --destructive: oklch(0.577 0.245 27.325);
-  --border: oklch(0.922 0 0);
-  --input: oklch(0.922 0 0);
-  --ring: oklch(0.708 0 0);
-  --chart-1: oklch(0.646 0.222 41.116);
-  --chart-2: oklch(0.6 0.118 184.704);
-  --chart-3: oklch(0.398 0.07 227.392);
-  --chart-4: oklch(0.828 0.189 84.429);
-  --chart-5: oklch(0.769 0.188 70.08);
-  --sidebar: oklch(0.985 0 0);
-  --sidebar-foreground: oklch(0.145 0 0);
-  --sidebar-primary: oklch(0.205 0 0);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.97 0 0);
-  --sidebar-accent-foreground: oklch(0.205 0 0);
-  --sidebar-border: oklch(0.922 0 0);
-  --sidebar-ring: oklch(0.708 0 0);
+
+  /* Borders */
+  --border: oklch(0.9 0.01 120);
+  --input: oklch(0.9 0.01 120);
+  --ring: oklch(0.68 0.15 135);
+
+  /* Charts - Green gradient scale */
+  --chart-1: oklch(0.95 0.18 130); /* Brightest lime */
+  --chart-2: oklch(0.82 0.16 132);
+  --chart-3: oklch(0.68 0.15 135); /* Mid green */
+  --chart-4: oklch(0.58 0.12 138);
+  --chart-5: oklch(0.48 0.1 140); /* Darker green */
+
+  /* Popover */
+  --popover: oklch(1 0 0);
+  --popover-foreground: oklch(0.25 0.01 120); /* Match foreground */
+
+  /* Sidebar */
+  --sidebar: oklch(0.98 0.002 120); /* Match background */
+  --sidebar-foreground: oklch(0.25 0.01 120); /* Dark text */
+  --sidebar-primary: oklch(0.68 0.15 135); /* Your green */
+  --sidebar-primary-foreground: oklch(1 0 0); /* White */
+  --sidebar-accent: oklch(0.95 0.005 120); /* Light muted */
+  --sidebar-accent-foreground: oklch(0.25 0.01 120);
+  --sidebar-border: oklch(0.9 0.01 120); /* Match border */
+  --sidebar-ring: oklch(0.68 0.15 135); /* Match ring */
 }
 
 .dark {
-  --background: oklch(0.145 0 0);
-  --foreground: oklch(0.985 0 0);
-  --card: oklch(0.205 0 0);
-  --card-foreground: oklch(0.985 0 0);
-  --popover: oklch(0.205 0 0);
-  --popover-foreground: oklch(0.985 0 0);
-  --primary: oklch(0.922 0 0);
-  --primary-foreground: oklch(0.205 0 0);
-  --secondary: oklch(0.269 0 0);
-  --secondary-foreground: oklch(0.985 0 0);
-  --muted: oklch(0.269 0 0);
-  --muted-foreground: oklch(0.708 0 0);
-  --accent: oklch(0.269 0 0);
-  --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
-  --border: oklch(1 0 0 / 10%);
-  --input: oklch(1 0 0 / 15%);
-  --ring: oklch(0.556 0 0);
-  --chart-1: oklch(0.488 0.243 264.376);
-  --chart-2: oklch(0.696 0.17 162.48);
-  --chart-3: oklch(0.769 0.188 70.08);
-  --chart-4: oklch(0.627 0.265 303.9);
-  --chart-5: oklch(0.645 0.246 16.439);
-  --sidebar: oklch(0.205 0 0);
-  --sidebar-foreground: oklch(0.985 0 0);
-  --sidebar-primary: oklch(0.488 0.243 264.376);
-  --sidebar-primary-foreground: oklch(0.985 0 0);
-  --sidebar-accent: oklch(0.269 0 0);
-  --sidebar-accent-foreground: oklch(0.985 0 0);
-  --sidebar-border: oklch(1 0 0 / 10%);
-  --sidebar-ring: oklch(0.556 0 0);
+  /* Backgrounds */
+  --background: oklch(0.18 0.01 120);
+  --foreground: oklch(0.98 0 0);
+
+  /* Cards */
+  --card: oklch(0.22 0.01 120);
+  --card-foreground: oklch(0.98 0 0);
+
+  /* Primary */
+  --primary: oklch(0.75 0.16 133); /* Brighter green for dark mode */
+  --primary-foreground: oklch(0.15 0.01 120); /* Dark text on bright green */
+
+  /* Secondary */
+  --secondary: oklch(0.3 0.02 120);
+  --secondary-foreground: oklch(0.98 0 0);
+
+  /* Muted */
+  --muted: oklch(0.3 0.02 120);
+  --muted-foreground: oklch(0.7 0.015 120);
+
+  /* Accent */
+  --accent: oklch(0.85 0.16 130);
+  --accent-foreground: oklch(0.15 0.01 120);
+
+  /* Destructive */
+  --destructive: oklch(0.65 0.2 25);
+
+  /* Borders */
+  --border: oklch(0.3 0.01 120);
+  --input: oklch(0.3 0.01 120);
+  --ring: oklch(0.75 0.16 133);
+
+  /* Popover */
+  --popover: oklch(0.22 0.01 120);
+  --popover-foreground: oklch(0.98 0 0);
+
+  /* Sidebar */
+  --sidebar: oklch(0.22 0.01 120);
+  --sidebar-foreground: oklch(0.98 0 0);
+  --sidebar-primary: oklch(0.75 0.16 133);
+  --sidebar-primary-foreground: oklch(0.15 0.01 120);
+  --sidebar-accent: oklch(0.3 0.02 120);
+  --sidebar-accent-foreground: oklch(0.98 0 0);
+  --sidebar-border: oklch(0.3 0.01 120);
+  --sidebar-ring: oklch(0.75 0.16 133);
 }
 
 @layer base {


### PR DESCRIPTION
## Description

Set base theme for shadcn components based on figma design/color scheme.

## Changes

- Configure OKLCH color variables matching Figma design
- Set primary green gradient (#5a8f3a to #c8ff8c)
- Add light and dark mode variants
- Update all shadcn component colors (primary, secondary, accent, etc.)

## Related Issues

Closes #94 

## Type of Change

<!-- Mark with an x -->

- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactor/chore

## Testing

<!-- How was this tested? -->

- [x] Tested locally
- [x] All checks passing
- [x] No console errors

## Screenshots (if applicable)



## Notes

CSS linter flags @ rules plugin, custom-variant, theme, and apply, didnt prevent npm run dev.
