### PR TITLE
fix: add edge case hamdling for scope filtering events

### DIFF
--- a/client/app/events/filters-to-query-params.test.ts
+++ b/client/app/events/filters-to-query-params.test.ts
@@ -133,13 +133,13 @@ describe("filtersToQueryParams", () => {
       expect(params.getAll("organization_id")).toEqual(["20", "30"]);
     });
 
-    it("should produce no organization_id params when scope is 'myOrgs' but user has no roles", () => {
+    it("should add organization_id=-1 when scope is 'myOrgs' but user has no roles", () => {
       const filters: Filters = { scope: "myOrgs", availability: null };
 
       const params = filtersToQueryParams(filters, []);
 
-      expect(params.has("organization_id")).toBe(false);
-      expect(params.toString()).toBe("");
+      expect(params.getAll("organization_id")).toEqual(["-1"]);
+      expect(params.toString()).toBe("organization_id=-1 ");
     });
 
     it("should combine organization_id with availability params", () => {

--- a/client/app/events/filters-to-query-params.test.ts
+++ b/client/app/events/filters-to-query-params.test.ts
@@ -139,7 +139,7 @@ describe("filtersToQueryParams", () => {
       const params = filtersToQueryParams(filters, []);
 
       expect(params.getAll("organization_id")).toEqual(["-1"]);
-      expect(params.toString()).toBe("organization_id=-1 ");
+      expect(params.toString()).toBe("organization_id=-1");
     });
 
     it("should combine organization_id with availability params", () => {

--- a/client/app/events/filters-to-query-params.ts
+++ b/client/app/events/filters-to-query-params.ts
@@ -26,14 +26,24 @@ export function filtersToQueryParams(
 
   // Map scope to organization_id query params
   if (filters.scope === "myOrgs") {
-    userRoles
-      .map((r) => r.organization_id)
-      .forEach((id) => params.append("organization_id", String(id)));
+    if (userRoles.length === 0) {
+      // No roles means no orgs, so add a param that will yield zero results
+      params.append("organization_id", "-1");
+    } else {
+      userRoles
+        .map((r) => r.organization_id)
+        .forEach((id) => params.append("organization_id", String(id)));
+    }
   } else if (filters.scope === "admin") {
-    userRoles
-      .filter((r) => r.permission_level === "admin")
-      .map((r) => r.organization_id)
-      .forEach((id) => params.append("organization_id", String(id)));
+    const adminRoles = userRoles.filter((r) => r.permission_level === "admin");
+    if (adminRoles.length === 0) {
+      // No admin roles means no orgs, so add a param that will yield zero results
+      params.append("organization_id", "-1");
+    } else {
+      adminRoles
+        .map((r) => r.organization_id)
+        .forEach((id) => params.append("organization_id", String(id)));
+    }
   }
 
   // Map selected categories to category query params


### PR DESCRIPTION
## Description

Add edge case handling for when user has not joined an organization or is not an admin

## Changes

- Add an if case to catch for length of 0 to myOrg and admin scope in `filters-to-query-params.ts`

## Related Issues

Closes #229 

## Type of Change

<!-- Mark with an x -->

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactor/chore

## Testing

<!-- How was this tested? -->

- [x] Tested locally
- [x] All checks passing
- [x] No console errors

## Screenshots (if applicable)

<img width="1361" height="777" alt="events_page2" src="https://github.com/user-attachments/assets/e33bb526-6cfb-4e3b-8e2a-0739c162afbf" />
<img width="1367" height="780" alt="events_page" src="https://github.com/user-attachments/assets/8a9836b7-14af-47db-ae5f-d1fc691491fa" />

## Notes

<!-- Anything reviewers should know? -->
